### PR TITLE
Feat/nft flow generalization

### DIFF
--- a/rust/rebase/src/proof/nft_ownership.rs
+++ b/rust/rebase/src/proof/nft_ownership.rs
@@ -1,6 +1,6 @@
 use crate::{
     content::nft_ownership::NftOwnership as Ctnt,
-    statement::nft_ownership::NftOwnership as Stmt,
+    statement::nft_ownership::AlchemyStatement as Stmt,
     types::{
         defs::{Proof, Statement},
         error::{ProofError, StatementError},
@@ -11,18 +11,18 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, JsonSchema, Serialize)]
 #[serde(rename = "proof")]
-pub struct NftOwnership {
+pub struct AlchemyProof {
     pub signature: String,
     pub statement: Stmt,
 }
 
-impl Statement for NftOwnership {
+impl Statement for AlchemyProof {
     fn generate_statement(&self) -> Result<String, StatementError> {
         self.statement.generate_statement()
     }
 }
 
-impl Proof<Ctnt> for NftOwnership {
+impl Proof<Ctnt> for AlchemyProof {
     fn to_content(&self, statement: &str, signature: &str) -> Result<Ctnt, ProofError> {
         Ok(Ctnt {
             contract_address: self.statement.contract_address.clone(),

--- a/rust/rebase/src/statement/nft_ownership.rs
+++ b/rust/rebase/src/statement/nft_ownership.rs
@@ -1,32 +1,33 @@
 use crate::types::{
-    defs::{Statement, Subject},
+    defs::{AlchemyNetworks, Statement, Subject},
     enums::subject::Subjects,
     error::StatementError,
 };
+use chrono::DateTime;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // TODO: Change this to an enum of possible chains / details.
-// Will match an Alchemy specific instance of NftOwnership
-// As SendGrid is to Email.
 #[derive(Clone, Deserialize, JsonSchema, Serialize)]
 #[serde(rename = "statement")]
-pub struct NftOwnership {
+pub struct AlchemyStatement {
     pub contract_address: String,
     pub subject: Subjects,
-    pub network: String,
+    pub network: AlchemyNetworks,
     pub issued_at: String,
 }
 
-impl Statement for NftOwnership {
+impl Statement for AlchemyStatement {
     fn generate_statement(&self) -> Result<String, StatementError> {
-        // TODO: Parse issued_at for valid date.
+        DateTime::parse_from_rfc3339(&self.issued_at)
+            .map_err(|e| StatementError::Statement(format!("failed to parse issued_at: {}", e)))?;
+
         Ok(format!(
             "The {} {} owns an asset from the contract {} on the network {} at time of {}",
             self.subject.statement_title()?,
             self.subject.display_id()?,
             self.contract_address,
-            self.network,
+            self.network.to_string(),
             self.issued_at,
         ))
     }

--- a/rust/rebase/src/statement/poap_ownership.rs
+++ b/rust/rebase/src/statement/poap_ownership.rs
@@ -3,6 +3,7 @@ use crate::types::{
     enums::subject::Subjects,
     error::StatementError,
 };
+use chrono::DateTime;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -16,7 +17,9 @@ pub struct PoapOwnership {
 
 impl Statement for PoapOwnership {
     fn generate_statement(&self) -> Result<String, StatementError> {
-        // TODO: Parse issued_at for valid date.
+        DateTime::parse_from_rfc3339(&self.issued_at)
+            .map_err(|e| StatementError::Statement(format!("failed to parse issued_at: {}", e)))?;
+
         Ok(format!(
             "The {} {} has a POAP for event id {} at time of {}",
             self.subject.statement_title()?,

--- a/rust/rebase/src/types/defs.rs
+++ b/rust/rebase/src/types/defs.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
 use did_web::DIDWeb;
 use schemars::schema::RootSchema;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use ssi::{
@@ -177,4 +178,23 @@ where
     }
 
     async fn validate_proof<I: Issuer>(&self, proof: &P, issuer: &I) -> Result<C, FlowError>;
+}
+
+// NOTE: Currently only supports main-nets. Other networks could be added here.
+// The serialized string variant is what is used in requests to Alchemy's API.
+#[derive(Clone, Deserialize, JsonSchema, Serialize)]
+pub enum AlchemyNetworks {
+    #[serde(rename = "eth-mainnet")]
+    EthMainnet,
+    #[serde(rename = "polygon-mainnet")]
+    PolygonMainnet,
+}
+
+impl std::string::ToString for AlchemyNetworks {
+    fn to_string(&self) -> String {
+        match self {
+            AlchemyNetworks::EthMainnet => "eth-mainnet".to_string(),
+            AlchemyNetworks::PolygonMainnet => "polygon-mainnet".to_string(),
+        }
+    }
 }

--- a/rust/rebase_witness_sdk/src/types.rs
+++ b/rust/rebase_witness_sdk/src/types.rs
@@ -14,17 +14,15 @@ use rebase::{
         soundcloud::SoundCloudFlow, twitter::TwitterFlow,
     },
     proof::{
-        email::Email as EmailProof, github::GitHub as GitHubProof,
-        nft_ownership::NftOwnership as NftOwnershipProof,
+        email::Email as EmailProof, github::GitHub as GitHubProof, nft_ownership::AlchemyProof,
         poap_ownership::PoapOwnership as PoapOwnershipProof, same::Same as SameProof,
         twitter::Twitter as TwitterProof,
     },
     statement::{
         dns::Dns as DnsStmt, email::Email as EmailStmt, github::GitHub as GitHubStmt,
-        nft_ownership::NftOwnership as NftOwnershipStmt,
-        poap_ownership::PoapOwnership as PoapOwnershipStmt, reddit::Reddit as RedditStmt,
-        same::Same as SameStmt, soundcloud::SoundCloud as SoundCloudStmt,
-        twitter::Twitter as TwitterStmt,
+        nft_ownership::AlchemyStatement, poap_ownership::PoapOwnership as PoapOwnershipStmt,
+        reddit::Reddit as RedditStmt, same::Same as SameStmt,
+        soundcloud::SoundCloud as SoundCloudStmt, twitter::Twitter as TwitterStmt,
     },
     types::{
         defs::{
@@ -142,8 +140,10 @@ pub enum Statements {
     Email(EmailStmt),
     #[serde(rename = "github")]
     GitHub(GitHubStmt),
+    // NOTE: If adding non-alchemy providers, this will need to change
+    // to an enum.
     #[serde(rename = "nft_ownership")]
-    NftOwnership(NftOwnershipStmt),
+    NftOwnership(AlchemyStatement),
     #[serde(rename = "poap_ownership")]
     PoapOwnership(PoapOwnershipStmt),
     #[serde(rename = "reddit")]
@@ -181,8 +181,10 @@ pub enum Proofs {
     Email(EmailProof),
     #[serde(rename = "github")]
     GitHub(GitHubProof),
+    // NOTE: If adding non-alchemy providers, this will need to change
+    // to an enum.
     #[serde(rename = "nft_ownership")]
-    NftOwnership(NftOwnershipProof),
+    NftOwnership(AlchemyProof),
     #[serde(rename = "poap_ownership")]
     PoapOwnership(PoapOwnershipProof),
     #[serde(rename = "reddit")]


### PR DESCRIPTION
Depends on #53, but otherwise is an updated version of the NFT flow made simpler, adding Polygon as an option for future flows, and leaving the door open for additional providers. Tested using ssx-credential-issuer, after #53 merges this can follow. Will be testable with the next PR to add POAP and NFT flows to the demo dapp.