### PR TITLE
Feat/add verify to rebase front end

### DIFF
--- a/demo/dapp/src/components/claims/ObtainedClaim.svelte
+++ b/demo/dapp/src/components/claims/ObtainedClaim.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
-    import { Claim, credentialToDisplay } from "utils";
-    import { IconButton, DownloadIcon, DeleteIcon, IconLink } from "components";
+    import { Claim, credentialToDisplay, client, alert } from "src/util";
+    import {
+        Button,
+        IconButton,
+        DownloadIcon,
+        DeleteIcon,
+        CheckmarkIcon,
+        IconLink,
+    } from "src/components";
 
     export let claim: Claim;
     export let removeClaim: Function;
@@ -8,6 +15,23 @@
     export const makeDownloadable = (jwt: string): string => {
         let encoded = encodeURIComponent(jwt);
         return `data:application/json;charset=utf-8,${encoded}`;
+    };
+
+    export const verify = async (jwt: string) => {
+        try {
+            let res = await client.verify_jwt(JSON.stringify({ jwt }));
+            console.log(res);
+            alert.set({
+                message: "Credential verified!",
+                variant: "success",
+            });
+        } catch (e) {
+            console.error(e);
+            alert.set({
+                variant: "error",
+                message: "Failed in verification",
+            });
+        }
     };
 </script>
 
@@ -56,6 +80,17 @@
                                 class="block w-4"
                                 onClick={() => removeClaim(claim, credential)}
                                 icon={DeleteIcon}
+                                color="#b3b3b3"
+                            />
+                        </div>
+                        <div class="w-2" />
+                        <div
+                            class="obtained-claim-action border border-gray-250 w-8 h-8 rounded-full flex flex-wrap align-center justify-center"
+                        >
+                            <IconButton
+                                class="block w-4"
+                                onClick={() => verify(credential)}
+                                icon={CheckmarkIcon}
                                 color="#b3b3b3"
                             />
                         </div>

--- a/demo/dapp/src/components/icons/CheckmarkIcon.svelte
+++ b/demo/dapp/src/components/icons/CheckmarkIcon.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+    import { iconColor as fillColor } from "utils";
+    export let color;
+</script>
+
+<svg
+    height="20"
+    width="20"
+    version="1.1"
+    id="Capa_1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    viewBox="0 0 17.837 17.837"
+    xml:space="preserve"
+>
+    <g>
+        <path
+            fill={color ?? fillColor}
+            d="M16.145,2.571c-0.272-0.273-0.718-0.273-0.99,0L6.92,10.804l-4.241-4.27
+		c-0.272-0.274-0.715-0.274-0.989,0L0.204,8.019c-0.272,0.271-0.272,0.717,0,0.99l6.217,6.258c0.272,0.271,0.715,0.271,0.99,0
+		L17.63,5.047c0.276-0.273,0.276-0.72,0-0.994L16.145,2.571z"
+        />
+    </g>
+</svg>

--- a/demo/dapp/src/components/icons/index.ts
+++ b/demo/dapp/src/components/icons/index.ts
@@ -1,3 +1,4 @@
+export { default as CheckmarkIcon } from './CheckmarkIcon.svelte';
 export { default as GitHubIcon } from './GitHubIcon.svelte';
 export { default as GlobeIcon } from './GlobeIcon.svelte';
 export { default as KeyIcon } from './KeyIcon.svelte';


### PR DESCRIPTION
Adds a checkmark button to the Obtained credential's page that when clicked will send the VC for verification to the Witness. This functionality was used in other projects, and this PR exposes the functionality to the demo dapp for demonstrative / testing purposes.