### PR TITLE
Feat/split witness secrets and config

### DIFF
--- a/rust/rebase/src/flow/email.rs
+++ b/rust/rebase/src/flow/email.rs
@@ -139,7 +139,7 @@ impl Flow<Ctnt, Stmt, Prf> for SendGridBasic {
         let challenge_vec: Vec<&str> = proof.challenge.split(&self.challenge_delimiter).collect();
         if challenge_vec.len() != 2 {
             return Err(FlowError::Validation(
-                "Challenge in unexpected formatt".to_string(),
+                "Challenge in unexpected format".to_string(),
             ));
         }
 

--- a/rust/rebase/src/flow/nft_ownership.rs
+++ b/rust/rebase/src/flow/nft_ownership.rs
@@ -1,7 +1,7 @@
 use crate::{
     content::nft_ownership::NftOwnership as Ctnt,
-    proof::nft_ownership::AlchemyProof as Prf,
-    statement::nft_ownership::AlchemyStatement as Stmt,
+    proof::nft_ownership::NftOwnershipProof as Prf,
+    statement::nft_ownership::NftOwnershipStatement as Stmt,
     types::{
         defs::{Flow, FlowResponse, Instructions, Issuer, Proof, Statement, Subject},
         enums::subject::{Pkh, Subjects},

--- a/rust/rebase/src/proof/nft_ownership.rs
+++ b/rust/rebase/src/proof/nft_ownership.rs
@@ -1,6 +1,6 @@
 use crate::{
     content::nft_ownership::NftOwnership as Ctnt,
-    statement::nft_ownership::AlchemyStatement as Stmt,
+    statement::nft_ownership::NftOwnershipStatement as Stmt,
     types::{
         defs::{Proof, Statement},
         error::{ProofError, StatementError},
@@ -11,18 +11,18 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, JsonSchema, Serialize)]
 #[serde(rename = "proof")]
-pub struct AlchemyProof {
+pub struct NftOwnershipProof {
     pub signature: String,
     pub statement: Stmt,
 }
 
-impl Statement for AlchemyProof {
+impl Statement for NftOwnershipProof {
     fn generate_statement(&self) -> Result<String, StatementError> {
         self.statement.generate_statement()
     }
 }
 
-impl Proof<Ctnt> for AlchemyProof {
+impl Proof<Ctnt> for NftOwnershipProof {
     fn to_content(&self, statement: &str, signature: &str) -> Result<Ctnt, ProofError> {
         Ok(Ctnt {
             contract_address: self.statement.contract_address.clone(),

--- a/rust/rebase/src/statement/nft_ownership.rs
+++ b/rust/rebase/src/statement/nft_ownership.rs
@@ -7,17 +7,16 @@ use chrono::DateTime;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-// TODO: Change this to an enum of possible chains / details.
 #[derive(Clone, Deserialize, JsonSchema, Serialize)]
 #[serde(rename = "statement")]
-pub struct AlchemyStatement {
+pub struct NftOwnershipStatement {
     pub contract_address: String,
     pub subject: Subjects,
     pub network: AlchemyNetworks,
     pub issued_at: String,
 }
 
-impl Statement for AlchemyStatement {
+impl Statement for NftOwnershipStatement {
     fn generate_statement(&self) -> Result<String, StatementError> {
         DateTime::parse_from_rfc3339(&self.issued_at)
             .map_err(|e| StatementError::Statement(format!("failed to parse issued_at: {}", e)))?;

--- a/rust/rebase/src/statement/poap_ownership.rs
+++ b/rust/rebase/src/statement/poap_ownership.rs
@@ -10,6 +10,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Deserialize, JsonSchema, Serialize)]
 #[serde(rename = "statement")]
 pub struct PoapOwnership {
+    // NOTE: This should ideally be a u64
+    // i64 is being used because it comes out
+    // correctly in the JSON Schema
+    // The Rust JSON Schema lib adds a marker
+    // for the u64 that the JS lib cannot understand
+    // There is likely a clean way to use u64, but
+    // the only consequence of a negative event id
+    // is not finding anything on look up.
     pub event_id: i64,
     pub issued_at: String,
     pub subject: Subjects,

--- a/rust/rebase_witness_sdk/src/types.rs
+++ b/rust/rebase_witness_sdk/src/types.rs
@@ -14,13 +14,13 @@ use rebase::{
         soundcloud::SoundCloudFlow, twitter::TwitterFlow,
     },
     proof::{
-        email::Email as EmailProof, github::GitHub as GitHubProof, nft_ownership::AlchemyProof,
-        poap_ownership::PoapOwnership as PoapOwnershipProof, same::Same as SameProof,
-        twitter::Twitter as TwitterProof,
+        email::Email as EmailProof, github::GitHub as GitHubProof,
+        nft_ownership::NftOwnershipProof, poap_ownership::PoapOwnership as PoapOwnershipProof,
+        same::Same as SameProof, twitter::Twitter as TwitterProof,
     },
     statement::{
         dns::Dns as DnsStmt, email::Email as EmailStmt, github::GitHub as GitHubStmt,
-        nft_ownership::AlchemyStatement, poap_ownership::PoapOwnership as PoapOwnershipStmt,
+        nft_ownership::NftOwnershipStatement, poap_ownership::PoapOwnership as PoapOwnershipStmt,
         reddit::Reddit as RedditStmt, same::Same as SameStmt,
         soundcloud::SoundCloud as SoundCloudStmt, twitter::Twitter as TwitterStmt,
     },
@@ -140,10 +140,8 @@ pub enum Statements {
     Email(EmailStmt),
     #[serde(rename = "github")]
     GitHub(GitHubStmt),
-    // NOTE: If adding non-alchemy providers, this will need to change
-    // to an enum.
     #[serde(rename = "nft_ownership")]
-    NftOwnership(AlchemyStatement),
+    NftOwnership(NftOwnershipStatement),
     #[serde(rename = "poap_ownership")]
     PoapOwnership(PoapOwnershipStmt),
     #[serde(rename = "reddit")]
@@ -181,10 +179,8 @@ pub enum Proofs {
     Email(EmailProof),
     #[serde(rename = "github")]
     GitHub(GitHubProof),
-    // NOTE: If adding non-alchemy providers, this will need to change
-    // to an enum.
     #[serde(rename = "nft_ownership")]
-    NftOwnership(AlchemyProof),
+    NftOwnership(NftOwnershipProof),
     #[serde(rename = "poap_ownership")]
     PoapOwnership(PoapOwnershipProof),
     #[serde(rename = "reddit")]


### PR DESCRIPTION
Updates the Witness to take have a in-code configuration object for data that doesn't need to be secret. Data that must me secret still uses the Cloudflare Worker secrets methodology, but setting things like offsets, timeouts, and in-copy text is now just a value inside of `configDefaults` in `demo/dapp/witness/worker/worker.js`.

Should have no impact on end user and be fully testable via the links below.