### PR TITLE
Updates to use latest SSI and DID-Web

### DIFF
--- a/demo/dapp/package.json
+++ b/demo/dapp/package.json
@@ -51,7 +51,7 @@
 		"webpack-dev-server": "^4.7.3"
 	},
 	"dependencies": {
-		"@rebase-xyz/rebase-client": "0.8.0",
+		"@rebase-xyz/rebase-client": "0.9.1",
 		"@walletconnect/web3-provider": "^1.7.8",
 		"ajv": "^8.11.0",
 		"ajv-formats": "^2.1.1",

--- a/rust/rebase/Cargo.lock
+++ b/rust/rebase/Cargo.lock
@@ -911,6 +911,8 @@ dependencies = [
 [[package]]
 name = "did-web"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8baea04ae1358a23bf460378573f4df91bab76c5f410455efcf2a8db476309"
 dependencies = [
  "async-trait",
  "http",
@@ -3210,6 +3212,8 @@ dependencies = [
 [[package]]
 name = "ssi"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a74add6dcfc3599495a73e953a7126ea19e9a0fc81860f5d593cabf1322cdf9"
 dependencies = [
  "ssi-caips",
  "ssi-core",
@@ -3230,6 +3234,8 @@ dependencies = [
 [[package]]
 name = "ssi-caips"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2c479690955bebece0279a5b1ab9d7d584402caed9f56ecec346d0bc63661f"
 dependencies = [
  "bs58",
  "ssi-jwk",
@@ -3239,10 +3245,14 @@ dependencies = [
 [[package]]
 name = "ssi-contexts"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286de2217e2ab66948fa8d69874ced77938d54ac2d2658444dc1d82ee502b882"
 
 [[package]]
 name = "ssi-core"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e43f42016b80dc3e5eae8f7d2b22db3debbfe97b38e4fa449433497b3513048"
 dependencies = [
  "async-trait",
  "serde",
@@ -3252,6 +3262,8 @@ dependencies = [
 [[package]]
 name = "ssi-crypto"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f41a12b15af9dce950a24a3295a2540be3b8500467621e31a97ddbe7618a5c8"
 dependencies = [
  "bs58",
  "digest 0.9.0",
@@ -3266,6 +3278,8 @@ dependencies = [
 [[package]]
 name = "ssi-dids"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e3c375b0fb2129c691e65e776c9105290ade34b56f39755f4f9c40ba98e41c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3289,6 +3303,8 @@ dependencies = [
 [[package]]
 name = "ssi-json-ld"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90b3723421b79dcefdbe65ee92d6f7a9d74b6d42de57afeca7d8286424faa14"
 dependencies = [
  "async-std",
  "combination",
@@ -3309,6 +3325,8 @@ dependencies = [
 [[package]]
 name = "ssi-jwk"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbaa04abdfe9de454fe34c0c49a4920a1c595c4ef12d357d17ce94a8a8da0910"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd 0.5.11",
@@ -3332,6 +3350,8 @@ dependencies = [
 [[package]]
 name = "ssi-jws"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9e36ec8624a4f81f21b0e407f1c2209c2cd89c0ff3c27b928999682b2e8912"
 dependencies = [
  "base64 0.12.3",
  "blake2",
@@ -3352,6 +3372,8 @@ dependencies = [
 [[package]]
 name = "ssi-jwt"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46522391b37f4b749911bb29b3960a7e2e0b9936c7debf52035f431480b40123"
 dependencies = [
  "chrono",
  "serde",
@@ -3364,7 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "ssi-ldp"
-version = "0.2.0"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de930bb18e3ed3c1f7b0a2b2b4fdba2887dffff34bb5f44b9967a983fea2d60c"
 dependencies = [
  "async-trait",
  "bs58",
@@ -3397,6 +3421,8 @@ dependencies = [
 [[package]]
 name = "ssi-ssh"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22967c7882e2457a2813badebf613a1b6ea3240f77ccac5c7c03858806d56618"
 dependencies = [
  "sshkeys",
  "ssi-jwk",
@@ -3406,6 +3432,8 @@ dependencies = [
 [[package]]
 name = "ssi-tzkey"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b57d919e20d214253a9a8dbc5f3b08ff555364934d99a09c828becab27a823"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -3417,6 +3445,8 @@ dependencies = [
 [[package]]
 name = "ssi-ucan"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0982f62c7860922026a9d9edc6c604de79693ee4c5c6bd65be11e2ff66b1df09"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -3435,7 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "ssi-vc"
-version = "0.1.1"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7a9a9dc254d976962fea4501ed40097b8a7c23c15f076a7f46fa97ed886bc7"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3463,6 +3495,8 @@ dependencies = [
 [[package]]
 name = "ssi-zcap-ld"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6b6a1e8e36842c9f69209f3ea0da7e979da126d352734a94a5eae2ed01ede1"
 dependencies = [
  "async-trait",
  "iref",

--- a/rust/rebase/Cargo.toml
+++ b/rust/rebase/Cargo.toml
@@ -9,8 +9,7 @@ edition = "2021"
 async-trait = "0.1.53"
 base58 = "0.2.0"
 chrono = { version = "0.4", features = ["serde", "wasmbind"] }
-# did-web = "0.1.2"
-did-web = { path = "../../../ssi/did-web", default-features = false}
+did-web = "0.2.1"
 ed25519-dalek = "1" 
 hex = "0.3"
 k256 = { version = "0.11", default-features = false, features = ["std", "ecdsa", "keccak256"] }
@@ -22,8 +21,7 @@ schemars = { version = "0.8", features = ["chrono"] }
 serde = "1"
 serde_json = "1"
 sha3 = "0.9"
-ssi = { path = "../../../ssi", default-features = false, features = ["ed25519", "secp256k1", "secp256r1"] }
-# ssi = { version = "0.5", default-features = false, features = ["ed25519", "secp256k1", "secp256r1"] }
+ssi = { version = "0.6", default-features = false, features = ["ed25519", "secp256k1", "secp256r1"] }
 
 thiserror = "1"
 ts-rs = "6.2"

--- a/rust/rebase_witness_sdk/Cargo.lock
+++ b/rust/rebase_witness_sdk/Cargo.lock
@@ -911,6 +911,8 @@ dependencies = [
 [[package]]
 name = "did-web"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8baea04ae1358a23bf460378573f4df91bab76c5f410455efcf2a8db476309"
 dependencies = [
  "async-trait",
  "http",
@@ -3224,6 +3226,8 @@ dependencies = [
 [[package]]
 name = "ssi"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a74add6dcfc3599495a73e953a7126ea19e9a0fc81860f5d593cabf1322cdf9"
 dependencies = [
  "ssi-caips",
  "ssi-core",
@@ -3244,6 +3248,8 @@ dependencies = [
 [[package]]
 name = "ssi-caips"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2c479690955bebece0279a5b1ab9d7d584402caed9f56ecec346d0bc63661f"
 dependencies = [
  "bs58",
  "ssi-jwk",
@@ -3253,10 +3259,14 @@ dependencies = [
 [[package]]
 name = "ssi-contexts"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "286de2217e2ab66948fa8d69874ced77938d54ac2d2658444dc1d82ee502b882"
 
 [[package]]
 name = "ssi-core"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e43f42016b80dc3e5eae8f7d2b22db3debbfe97b38e4fa449433497b3513048"
 dependencies = [
  "async-trait",
  "serde",
@@ -3266,6 +3276,8 @@ dependencies = [
 [[package]]
 name = "ssi-crypto"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f41a12b15af9dce950a24a3295a2540be3b8500467621e31a97ddbe7618a5c8"
 dependencies = [
  "bs58",
  "digest 0.9.0",
@@ -3280,6 +3292,8 @@ dependencies = [
 [[package]]
 name = "ssi-dids"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e3c375b0fb2129c691e65e776c9105290ade34b56f39755f4f9c40ba98e41c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3303,6 +3317,8 @@ dependencies = [
 [[package]]
 name = "ssi-json-ld"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90b3723421b79dcefdbe65ee92d6f7a9d74b6d42de57afeca7d8286424faa14"
 dependencies = [
  "async-std",
  "combination",
@@ -3323,6 +3339,8 @@ dependencies = [
 [[package]]
 name = "ssi-jwk"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbaa04abdfe9de454fe34c0c49a4920a1c595c4ef12d357d17ce94a8a8da0910"
 dependencies = [
  "base64 0.12.3",
  "blake2b_simd 0.5.11",
@@ -3346,6 +3364,8 @@ dependencies = [
 [[package]]
 name = "ssi-jws"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9e36ec8624a4f81f21b0e407f1c2209c2cd89c0ff3c27b928999682b2e8912"
 dependencies = [
  "base64 0.12.3",
  "blake2",
@@ -3366,6 +3386,8 @@ dependencies = [
 [[package]]
 name = "ssi-jwt"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46522391b37f4b749911bb29b3960a7e2e0b9936c7debf52035f431480b40123"
 dependencies = [
  "chrono",
  "serde",
@@ -3378,7 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "ssi-ldp"
-version = "0.2.0"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de930bb18e3ed3c1f7b0a2b2b4fdba2887dffff34bb5f44b9967a983fea2d60c"
 dependencies = [
  "async-trait",
  "bs58",
@@ -3411,6 +3435,8 @@ dependencies = [
 [[package]]
 name = "ssi-ssh"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22967c7882e2457a2813badebf613a1b6ea3240f77ccac5c7c03858806d56618"
 dependencies = [
  "sshkeys",
  "ssi-jwk",
@@ -3420,6 +3446,8 @@ dependencies = [
 [[package]]
 name = "ssi-tzkey"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b57d919e20d214253a9a8dbc5f3b08ff555364934d99a09c828becab27a823"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -3431,6 +3459,8 @@ dependencies = [
 [[package]]
 name = "ssi-ucan"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0982f62c7860922026a9d9edc6c604de79693ee4c5c6bd65be11e2ff66b1df09"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -3449,7 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "ssi-vc"
-version = "0.1.1"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7a9a9dc254d976962fea4501ed40097b8a7c23c15f076a7f46fa97ed886bc7"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
@@ -3477,6 +3509,8 @@ dependencies = [
 [[package]]
 name = "ssi-zcap-ld"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6b6a1e8e36842c9f69209f3ea0da7e979da126d352734a94a5eae2ed01ede1"
 dependencies = [
  "async-trait",
  "iref",


### PR DESCRIPTION
Updates to ssi version 0.6 and did-web 0.2.1 rather than local filesystem copies. Tested from end to end, can be tested again through the links in the bottom. No code change, just dependencies listings.