### PR TITLE
Feat/clean up type names non breaking

### DIFF
--- a/demo/dapp/package.json
+++ b/demo/dapp/package.json
@@ -49,7 +49,7 @@
 		"webpack-dev-server": "^4.7.3"
 	},
 	"dependencies": {
-		"@rebase-xyz/rebase-client": "0.10.0",
+		"@rebase-xyz/rebase-client": "0.12.0",
 		"@walletconnect/web3-provider": "^1.7.8",
 		"ajv": "^8.11.0",
 		"ajv-formats": "^2.1.1",

--- a/demo/dapp/src/components/claims/ObtainedClaim.svelte
+++ b/demo/dapp/src/components/claims/ObtainedClaim.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { Claim, credentialToDisplay, client, alert } from "src/util";
     import {
-        Button,
         IconButton,
         DownloadIcon,
         DeleteIcon,
@@ -19,7 +18,7 @@
 
     export const verify = async (jwt: string) => {
         try {
-            let res = await client.verify_jwt(JSON.stringify({ jwt }));
+            let res = await client.verify({ jwt });
             console.log(res);
             alert.set({
                 message: "Credential verified!",
@@ -36,7 +35,7 @@
 </script>
 
 {#if claim.credentials.length !== 0}
-    <div class="obtained-claim py-2 w-full flex flex-wrap justify-between ">
+    <div class="obtained-claim py-2 w-full flex flex-wrap justify-between">
         <div class="flex flex-wrap w-full">
             <div class="flex flex-wrap justify-center items-center">
                 <div class="w-8 h-fit">

--- a/demo/dapp/src/components/form/SameForm.svelte
+++ b/demo/dapp/src/components/form/SameForm.svelte
@@ -208,7 +208,7 @@
         }
 
         try {
-            let res = await client.jwt({ proof });
+            let res = await client.witness_jwt({ proof });
             let { jwt } = res;
             setNew(jwt);
         } catch (e) {

--- a/demo/dapp/src/components/form/WitnessForm.svelte
+++ b/demo/dapp/src/components/form/WitnessForm.svelte
@@ -74,7 +74,7 @@
         claims.set(next);
     };
 
-    export let type: Types.InstructionsType;
+    export let type: Types.FlowType;
     export let instructions: Instructions;
 
     let statement: Writable<string> = writable("");
@@ -358,7 +358,7 @@
             let req: Types.WitnessReq = {
                 proof: opts as Types.Proofs,
             };
-            let res = await client.jwt(req);
+            let res = await client.witness_jwt(req);
             let { jwt } = res;
 
             setNew(jwt);

--- a/demo/dapp/src/components/form/witnessedselfissue/WitnessedSelfIssue.svelte
+++ b/demo/dapp/src/components/form/witnessedselfissue/WitnessedSelfIssue.svelte
@@ -112,7 +112,7 @@
         };
 
         // TODO: JSON Schema validation here!
-        let proofRes = await client.jwt(proofReq);
+        let proofRes = await client.witness_jwt(proofReq);
 
         // TODO: Check for missing JWT.
         if (!proofRes.jwt) {

--- a/demo/dapp/src/routes/Account.svelte
+++ b/demo/dapp/src/routes/Account.svelte
@@ -5,7 +5,7 @@
         BasePage,
         ToggleButton,
         Button,
-    } from "components";
+    } from "src/components";
     import { AccountState } from "utils";
     import { useNavigate } from "svelte-navigator";
     import { onMount } from "svelte";

--- a/demo/dapp/src/routes/Witness.svelte
+++ b/demo/dapp/src/routes/Witness.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { CredentialType, Instructions } from "../util";
+    import type { Instructions } from "../util";
     import { instructions, alert } from "../util";
     import { onMount } from "svelte";
     import {
@@ -9,8 +9,9 @@
         WitnessedSelfIssue,
     } from "src/components";
     import { writable, type Writable } from "svelte/store";
+    import { Types } from "@rebase-xyz/rebase-client";
 
-    export let type: CredentialType;
+    export let type: Types.FlowType;
 
     let inst: Writable<Instructions> = writable(null);
     let _inst: Instructions = null;
@@ -21,7 +22,7 @@
         try {
             if (
                 type !== "SameControllerAssertion" &&
-                type !== "WitnessedBasicProfile"
+                type !== "WitnessedSelfIssued"
             ) {
                 let i = await instructions(type);
                 inst.set(i as Instructions);

--- a/demo/dapp/src/util/claim.ts
+++ b/demo/dapp/src/util/claim.ts
@@ -179,7 +179,7 @@ export const credentialToDisplay = (jwt: string): CredentialDisplay => {
 export type Claim = {
     // NOTE: we could use object instead of string for credential, but for now, assume a JWT
     credentials: Array<string>,
-    credential_type: Types.InstructionsType,
+    credential_type: Types.FlowType,
     icon: ClaimIcon,
     title: string,
     type: ClaimType,

--- a/demo/dapp/src/util/witness.ts
+++ b/demo/dapp/src/util/witness.ts
@@ -7,13 +7,13 @@ const witnessUrl = process.env.WITNESS_URL;
 const clientConfig: Types.Endpoints = {
     instructions: `${witnessUrl}/instructions`,
     statement: `${witnessUrl}/statement`,
-    jwt: `${witnessUrl}/witness`,
-    verify_jwt: `${witnessUrl}/verify`
+    witness_jwt: `${witnessUrl}/witness`,
+    verify: `${witnessUrl}/verify`
 };
 
 export const client = new Client(new WasmClient(JSON.stringify(clientConfig)));
 
-export function needsDelimiter(c: Types.InstructionsType): boolean {
+export function needsDelimiter(c: Types.FlowType): boolean {
     switch (c) {
         case "GitHubVerification": 
         case "TwitterVerification":
@@ -63,7 +63,7 @@ const ICONS = {
     WitnessedSelfIssued: GlobeIcon,
 };
 
-export const titleCase = (s: Types.InstructionsType): string => {
+export const titleCase = (s: Types.FlowType): string => {
     switch (s) {
         case "DnsVerification":
             return "DNS";
@@ -95,7 +95,7 @@ interface WitnessInfo {
     witness_placeholder: string,
 }
 
-function witness_info(t: Types.InstructionsType): WitnessInfo {
+function witness_info(t: Types.FlowType): WitnessInfo {
     let statement = `Enter your ${titleCase(t)} account handle to verify and include it in a message signed via your wallet.`;
     let statement_label = "Enter Account Handle";
     let statement_placeholder =  `Enter your ${titleCase(t)} handle`;
@@ -166,7 +166,7 @@ function witness_info(t: Types.InstructionsType): WitnessInfo {
     }
 }
 
-export const instructions = async (t: Types.InstructionsType): Promise<Instructions> => {
+export const instructions = async (t: Types.FlowType): Promise<Instructions> => {
     let {statement, statement_label, statement_placeholder, witness, witness_label, witness_placeholder} = witness_info(t);
     switch (t) {
         case "WitnessedSelfIssued": {

--- a/js/rebase-client/binding_glue/manual/index.ts
+++ b/js/rebase-client/binding_glue/manual/index.ts
@@ -12,8 +12,7 @@ export class Client {
         this.client = client;
     }
 
-    // async instructions(type: Types.InstructionsType): Promise<Types.Instructions> {
-    async instructions(type: Types.InstructionsType): Promise<Types.Instructions> {
+    async instructions(type: Types.FlowType): Promise<Types.Instructions> {
         let req: Types.InstructionsReq = {
             type,
         };
@@ -23,20 +22,24 @@ export class Client {
         return res as Types.Instructions;
     }
 
-    // async statement(req: Types.StatementReq): Promise<Types.FlowResponse> {
     async statement(req: Types.StatementReq): Promise<Types.FlowResponse> {
         let res = await this.client.statement(JSON.stringify(req));
         return JSON.parse(res) as Types.FlowResponse;
     }
 
-    async jwt(req: Types.WitnessReq): Promise<Types.WitnessJWTRes> {
-        let res = await this.client.jwt(JSON.stringify(req));
-        return JSON.parse(res) as Types.WitnessJWTRes;
+    async witness_jwt(req: Types.WitnessReq): Promise<Types.JWTWrapper> {
+        let res = await this.client.witness_jwt(JSON.stringify(req));
+        return JSON.parse(res) as Types.JWTWrapper;
     }
 
-    // TODO: Regen the bindings, the use Types.VerificationReq
-    async verify(req: Types.WitnessJWTRes): Promise<Types.VerifyRes> {
-        let res = await this.client.verify_jwt(JSON.stringify(req));
+
+    async witness_ld(req: Types.WitnessReq): Promise<Types.CredentialWrapper> {
+        let res = await this.client.witness_ld(JSON.stringify(req));
+        return JSON.parse(res) as Types.CredentialWrapper;
+    }
+
+    async verify(req: Types.VCWrapper): Promise<Types.VerifyRes> {
+        let res = await this.client.verify(JSON.stringify(req));
         return JSON.parse(res) as Types.VerifyRes;
     }
 }

--- a/js/rebase-client/binding_glue/manual/package.json
+++ b/js/rebase-client/binding_glue/manual/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@rebase-xyz/rebase-client",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "description": "",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "ISC"
+  "author": ""
 }

--- a/js/rebase-client/package-lock.json
+++ b/js/rebase-client/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "rebase-client",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/js/rebase-client/src/lib.rs
+++ b/js/rebase-client/src/lib.rs
@@ -3,12 +3,10 @@ mod utils;
 use js_sys::Promise;
 use rebase_witness_sdk::{
     client::{Client as RebaseClient, Endpoints},
-    types::{InstructionsReq, StatementReq, VerifyJWTReq, VerifyLDReq, WitnessReq},
+    types::{InstructionsReq, StatementReq, VCWrapper, WitnessReq},
 };
-use serde::{Deserialize, Serialize};
 use serde_json::from_str;
 use std::sync::Arc;
-use url::Url;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
 
@@ -34,24 +32,11 @@ pub struct WasmClient {
     client: Arc<RebaseClient>,
 }
 
-#[wasm_bindgen]
-#[derive(Deserialize, Serialize)]
-pub struct Config {
-    instructions: String,
-    statement: String,
-    jwt: Option<String>,
-    ld: Option<String>,
-    verify_jwt: Option<String>,
-    verify_ld: Option<String>,
-}
-
-impl Config {
-    fn is_valid(&self) -> Result<(), String> {
-        if self.jwt.is_none() && self.ld.is_none() {
-            Err("At least one of JWT or LD urls must be set".to_string())
-        } else {
-            Ok(())
-        }
+fn is_valid(endpoints: &Endpoints) -> Result<(), String> {
+    if endpoints.witness_jwt.is_none() && endpoints.witness_ld.is_none() {
+        Err("At least one of JWT or LD witness urls must be set".to_string())
+    } else {
+        Ok(())
     }
 }
 
@@ -59,43 +44,11 @@ impl Config {
 impl WasmClient {
     #[wasm_bindgen(constructor)]
     pub fn new(config: &str) -> Result<WasmClient, String> {
-        let config: Config = from_str(config).map_err(|e| e.to_string())?;
-        config.is_valid()?;
+        let config: Endpoints = from_str(config).map_err(|e| e.to_string())?;
+        is_valid(&config)?;
 
-        let jwt: Option<Url> = match config.jwt {
-            Some(s) => Some(Url::parse(&s).map_err(|e| e.to_string())?),
-            None => None,
-        };
-
-        let verify_jwt: Option<Url> = match config.verify_jwt {
-            Some(s) => Some(Url::parse(&s).map_err(|e| e.to_string())?),
-            None => None,
-        };
-
-        let ld: Option<Url> = match config.ld {
-            Some(s) => Some(Url::parse(&s).map_err(|e| e.to_string())?),
-            None => None,
-        };
-
-        let verify_ld: Option<Url> = match config.verify_ld {
-            Some(s) => Some(Url::parse(&s).map_err(|e| e.to_string())?),
-            None => None,
-        };
-
-        let statement = Url::parse(&config.statement).map_err(|e| e.to_string())?;
-        let instructions = Url::parse(&config.instructions).map_err(|e| e.to_string())?;
         Ok(WasmClient {
-            client: Arc::new(
-                RebaseClient::new(Endpoints {
-                    jwt,
-                    ld,
-                    statement,
-                    instructions,
-                    verify_jwt,
-                    verify_ld,
-                })
-                .map_err(|e| e.to_string())?,
-            ),
+            client: Arc::new(RebaseClient::new(config).map_err(|e| e.to_string())?),
         })
     }
 
@@ -118,38 +71,29 @@ impl WasmClient {
         })
     }
 
-    pub fn jwt(&self, req: String) -> Promise {
+    pub fn witness_jwt(&self, req: String) -> Promise {
         let client = self.client.clone();
         future_to_promise(async move {
             let req: WitnessReq = jserr!(serde_json::from_str(&req));
-            let res = jserr!(client.jwt(req).await);
+            let res = jserr!(client.witness_jwt(req).await);
             Ok(jserr!(serde_json::to_string(&res)).into())
         })
     }
 
-    pub fn verify_jwt(&self, req: String) -> Promise {
-        let client = self.client.clone();
-        future_to_promise(async move {
-            let req: VerifyJWTReq = jserr!(serde_json::from_str(&req));
-            let res = jserr!(client.verify_jwt(req).await);
-            Ok(jserr!(serde_json::to_string(&res)).into())
-        })
-    }
-
-    pub fn ld(&self, req: String) -> Promise {
+    pub fn witness_ld(&self, req: String) -> Promise {
         let client = self.client.clone();
         future_to_promise(async move {
             let req: WitnessReq = jserr!(serde_json::from_str(&req));
-            let res = jserr!(client.ld(req).await);
+            let res = jserr!(client.witness_ld(req).await);
             Ok(jserr!(serde_json::to_string(&res)).into())
         })
     }
 
-    pub fn verify_ld(&self, req: String) -> Promise {
+    pub fn verify(&self, req: String) -> Promise {
         let client = self.client.clone();
         future_to_promise(async move {
-            let req: VerifyLDReq = jserr!(serde_json::from_str(&req));
-            let res = jserr!(client.verify_ld(req).await);
+            let req: VCWrapper = jserr!(serde_json::from_str(&req));
+            let res = jserr!(client.verify(req).await);
             Ok(jserr!(serde_json::to_string(&res)).into())
         })
     }

--- a/rust/rebase/src/types/defs.rs
+++ b/rust/rebase/src/types/defs.rs
@@ -1,33 +1,20 @@
 use crate::types::error::*;
 use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
-use did_web::DIDWeb;
+pub use did_web::DIDWeb;
 use schemars::schema::RootSchema;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use ssi::{
-    jsonld::ContextLoader as JSONLDContextLoader,
+pub use ssi::{
+    did_resolve::DIDResolver,
+    jsonld::ContextLoader,
     ldp::Proof as LDProof,
-    one_or_many::OneOrMany as SSIOneOrMany,
-    vc::{
-        Credential as SSICred, Evidence as SSIEvidence, LinkedDataProofOptions as LDPOpts,
-        URI as VCURI,
-    },
+    one_or_many::OneOrMany,
+    vc::{get_verification_method, Credential, Evidence, LinkedDataProofOptions, URI},
 };
 use ts_rs::TS;
 use uuid::Uuid;
-
-pub type Credential = SSICred;
-pub type ContextLoader = JSONLDContextLoader;
-pub type LinkedDataProofOptions = LDPOpts;
-pub type URI = VCURI;
-pub type OneOrMany<T> = SSIOneOrMany<T>;
-pub type Evidence = SSIEvidence;
-
-pub fn new_resolver() -> DIDWeb {
-    DIDWeb
-}
 
 #[async_trait(?Send)]
 pub trait Subject
@@ -38,6 +25,7 @@ where
 
     fn display_id(&self) -> Result<String, SubjectError>;
 
+    // TODO: Remove this when we use get_verification_method instead
     fn verification_method(&self) -> Result<String, SubjectError>;
 
     async fn valid_signature(&self, statement: &str, signature: &str) -> Result<(), SubjectError>;

--- a/rust/rebase_witness_sdk/README.md
+++ b/rust/rebase_witness_sdk/README.md
@@ -66,9 +66,9 @@ with `rebase::statement::dns::Dns` aliased to `DnsStmt` and so forth.
 
 The result of this is that given an instance of `Statements`, one can simply pass that instance to `WitnessFlow.statement` and get the expected result (presuming the flow is implemented in WitnessFlow).
 
-This pattern is matched for `Contents` and `Proofs`, as well as instructions (via `InstructionsType`).
+This pattern is matched for `Contents` and `Proofs`, as well as instructions (via `FlowType`).
 
-To support a new flow, a struct `impl`ing the flow has to be added (wrapped in an `Option`) to the `WitnessFlow` struct, then an entry added to each of the enums mentioned above (`InstructionsType`, `Statements`, `Contents`, and `Proofs`).
+To support a new flow, a struct `impl`ing the flow has to be added (wrapped in an `Option`) to the `WitnessFlow` struct, then an entry added to each of the enums mentioned above (`FlowType`, `Statements`, `Contents`, and `Proofs`).
 
 Then adding support in the `WitnessFlow`'s `impl` of `Flow` for each step. A very complex macro could probably decrease this work, but it isn't particularly sizable as is.
 
@@ -80,7 +80,7 @@ The shape of the requests and responses that the `WitnessFlow` can handle are al
 #[derive(Deserialize, Serialize)]
 pub struct InstructionsReq {
     #[serde(rename = "type")]
-    pub instruction_type: InstructionsType,
+    pub instruction_type: FlowType,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/rust/rebase_witness_sdk/examples/live_posts.rs
+++ b/rust/rebase_witness_sdk/examples/live_posts.rs
@@ -10,12 +10,11 @@ use url::Url;
 fn new_client(base_url: &str) -> Result<Client, String> {
     // TODO: Update to use a worker that supports LD routes.
     let endpoints = Endpoints {
-        jwt: Some(Url::parse(&format!("{}/witness", base_url)).unwrap()),
-        ld: None,
+        witness_jwt: Some(Url::parse(&format!("{}/witness", base_url)).unwrap()),
+        witness_ld: None,
         statement: Url::parse(&format!("{}/statement", base_url)).unwrap(),
         instructions: Url::parse(&format!("{}/instructions", base_url)).unwrap(),
-        verify_jwt: None,
-        verify_ld: None,
+        verify: None,
     };
 
     Client::new(endpoints).map_err(|e| e.to_string())
@@ -63,7 +62,7 @@ async fn main() {
         proof: Proofs::DnsVerification(inner.clone()),
     };
 
-    client.jwt(req).await.unwrap();
+    client.witness_jwt(req).await.unwrap();
 
     println!("DNS credential issued");
 
@@ -91,7 +90,7 @@ async fn main() {
         proof: Proofs::GitHubVerification(proof),
     };
 
-    client.jwt(req).await.unwrap();
+    client.witness_jwt(req).await.unwrap();
 
     println!("GitHub credential issued");
 
@@ -114,7 +113,7 @@ async fn main() {
         proof: Proofs::RedditVerification(inner),
     };
 
-    client.jwt(req).await.unwrap();
+    client.witness_jwt(req).await.unwrap();
 
     println!("Reddit credential issued");
 
@@ -137,7 +136,7 @@ async fn main() {
         proof: Proofs::SoundCloudVerification(inner),
     };
 
-    client.jwt(req).await.unwrap();
+    client.witness_jwt(req).await.unwrap();
 
     println!("SoundCloud credential issued");
 
@@ -166,7 +165,7 @@ async fn main() {
         proof: Proofs::TwitterVerification(proof),
     };
 
-    client.jwt(req).await.unwrap();
+    client.witness_jwt(req).await.unwrap();
 
     println!("Twitter credential issued");
 
@@ -198,7 +197,7 @@ async fn main() {
         proof: Proofs::SameControllerAssertion(proof),
     };
 
-    client.jwt(req).await.unwrap();
+    client.witness_jwt(req).await.unwrap();
 
     println!("Self Signed Credential issued");
     println!("All Ethereum Live Posts tested!");
@@ -229,7 +228,7 @@ async fn main() {
         proof: Proofs::GitHubVerification(proof),
     };
 
-    client.jwt(req).await.unwrap();
+    client.witness_jwt(req).await.unwrap();
 
     println!("GitHub credential issued");
     println!("Testing Twitter...");
@@ -257,7 +256,7 @@ async fn main() {
         proof: Proofs::TwitterVerification(proof),
     };
 
-    client.jwt(req).await.unwrap();
+    client.witness_jwt(req).await.unwrap();
 
     println!("Twitter credential issued");
 
@@ -288,7 +287,7 @@ async fn main() {
         proof: Proofs::SameControllerAssertion(proof),
     };
 
-    client.jwt(req).await.unwrap();
+    client.witness_jwt(req).await.unwrap();
 
     println!("Self Signed Credential issued");
 


### PR DESCRIPTION
This change handles all the non-breaking changes clean up captured in the pre-publication task lists. All current functionality continues to work across demos, and this PR can be tested by using the CF links below. 

rebase-client version `0.12.0` includes these changes.

Soon, there will be a breaking change that will require all UIs to update at the same time we publish a new worker -- but this is not that update.