### PR TITLE
Feat/remove backwards compat

### DIFF
--- a/demo/dapp/package.json
+++ b/demo/dapp/package.json
@@ -49,7 +49,7 @@
 		"webpack-dev-server": "^4.7.3"
 	},
 	"dependencies": {
-		"@rebase-xyz/rebase-client": "0.15.0",
+		"@rebase-xyz/rebase-client": "0.15.1",
 		"@walletconnect/web3-provider": "^1.7.8",
 		"ajv": "^8.11.0",
 		"ajv-formats": "^2.1.1",

--- a/demo/dapp/src/util/witness.ts
+++ b/demo/dapp/src/util/witness.ts
@@ -1,19 +1,20 @@
 import { TwitterIcon, GlobeIcon, GitHubIcon, DiscordIcon, EmailIcon, RedditIcon, SoundCloudIcon } from "src/components/icons";
 import { WasmClient } from "@rebase-xyz/rebase-client/wasm";
-import { Client, Types } from "@rebase-xyz/rebase-client";
+import { Client, defaultClientConfig, Types } from "@rebase-xyz/rebase-client";
 
-const witnessUrl = process.env.WITNESS_URL;
+// USE FOR DEBUG:
+// const witnessUrl = process.env.WITNESS_URL;
+// const clientConfig: Types.ClientConfig = { 
+//     endpoints: {
+//         instructions: `${witnessUrl}/instructions`,
+//         statement: `${witnessUrl}/statement`,
+//         witness_jwt: `${witnessUrl}/witness_jwt`,
+//         witness_ld: `${witnessUrl}/witness_ld`,
+//         verify: `${witnessUrl}/verify`
+//     },
+// };
 
-const clientConfig: Types.ClientConfig = { 
-    endpoints: {
-        instructions: `${witnessUrl}/instructions`,
-        statement: `${witnessUrl}/statement`,
-        witness_jwt: `${witnessUrl}/witness_jwt`,
-        witness_ld: `${witnessUrl}/witness_ld`,
-        verify: `${witnessUrl}/verify`
-    },
-};
-
+const clientConfig = defaultClientConfig();
 export const client = new Client(new WasmClient(JSON.stringify(clientConfig)));
 
 export function needsDelimiter(c: Types.FlowType): boolean {

--- a/demo/dapp/webpack.config.js
+++ b/demo/dapp/webpack.config.js
@@ -106,6 +106,7 @@ module.exports = {
 			index: '/index.html',
 		},
 	},
+	// NOTE: This is key to getting WASM to work.
 	experiments: {
 		asyncWebAssembly: true,
 	},

--- a/js/rebase-client/binding_glue/manual/index.ts
+++ b/js/rebase-client/binding_glue/manual/index.ts
@@ -5,6 +5,21 @@ export type {
     Types
 }
 
+const DEFAULT_WITNESS_URL = "https://rebasedemo.spruceid.workers.dev"
+
+// This returns a client config pointed to the Spruce ID witness.
+export const defaultClientConfig = (): Types.ClientConfig => {
+    return {
+        endpoints: { 
+            instructions: `${DEFAULT_WITNESS_URL}/instructions`,
+            statement: `${DEFAULT_WITNESS_URL}/statement`,
+            witness_jwt: `${DEFAULT_WITNESS_URL}/witness_jwt`,
+            witness_ld: `${DEFAULT_WITNESS_URL}/witness_ld`,
+            verify: `${DEFAULT_WITNESS_URL}/verify`
+        }
+    }
+};
+
 export class Client {
     readonly client: WasmClient; 
 

--- a/js/rebase-client/binding_glue/manual/package.json
+++ b/js/rebase-client/binding_glue/manual/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rebase-xyz/rebase-client",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/js/rebase-client/src/lib.rs
+++ b/js/rebase-client/src/lib.rs
@@ -64,7 +64,6 @@ impl WasmClient {
         let client = self.client.clone();
         future_to_promise(async move {
             let req: Statements = jserr!(serde_json::from_str(&req));
-            // TODO: Work from here to extricate witness error, if exists.
             let res = jserr!(client.statement(req).await);
             Ok(jserr!(serde_json::to_string(&res)).into())
         })

--- a/rust/rebase/src/types/defs.rs
+++ b/rust/rebase/src/types/defs.rs
@@ -1,7 +1,6 @@
 use crate::types::error::*;
 use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
-// TODO: Pub use these?
 use did_ethr::DIDEthr;
 use did_ion::DIDION;
 use did_jwk::DIDJWK;

--- a/rust/rebase_cf_worker/src/lib.rs
+++ b/rust/rebase_cf_worker/src/lib.rs
@@ -1,9 +1,8 @@
 use rebase_witness_sdk::types::{
-    handle_verify, issuer::ed25519::DidWebJwk, Alchemy, AttestationFlow, CompatStatementReq,
-    CompatWitnessReq, DnsVerificationFlow, EmailVerificationFlow, GitHubVerificationFlow,
-    InstructionsReq, NftOwnershipVerificationFlow, PoapOwnershipVerificationFlow,
-    RedditVerificationFlow, SameControllerAssertionFlow, SoundCloudVerificationFlow,
-    TwitterVerificationFlow, VCWrapper, WitnessFlow,
+    handle_verify, issuer::ed25519::DidWebJwk, Alchemy, AttestationFlow, DnsVerificationFlow,
+    EmailVerificationFlow, GitHubVerificationFlow, InstructionsReq, NftOwnershipVerificationFlow,
+    PoapOwnershipVerificationFlow, Proofs, RedditVerificationFlow, SameControllerAssertionFlow,
+    SoundCloudVerificationFlow, Statements, TwitterVerificationFlow, VCWrapper, WitnessFlow,
 };
 use serde_json::json;
 use worker::*;
@@ -169,22 +168,8 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         // TODO: Investigate if there is a wild card pattern instead of repetition
         .options("/statement", |_req, _ctx| preflight_response())
         .post_async("/statement", |mut req, ctx| async move {
-            // TODO: REMOVE ONCE PUBLISHED TO REMOVE BACKWARDS COMPAT
-            if let Ok(b) = req.json::<CompatStatementReq>().await {
+            if let Ok(b) = req.json::<Statements>().await {
                 if let Ok(r) = ctx.data.0.handle_statement(&b, &ctx.data.1).await {
-                    let res = Response::from_json(&r)?;
-                    return Ok(res.with_headers(post_resp_headers()?));
-                };
-            };
-            Response::error("Bad Request", 400)
-        })
-        // TODO: DEPERECATE THIS  "/witness" ROUTE, THIS SUPPORTS PRE 0.13.0 REBASE CLIENTS.
-        // TODO: Investigate if there is a wild card pattern instead of repetition
-        .options("/witness", |_req, _ctx| preflight_response())
-        .post_async("/witness", |mut req, ctx| async move {
-            // TODO: REMOVE ONCE PUBLISHED TO REMOVE BACKWARDS COMPAT
-            if let Ok(b) = req.json::<CompatWitnessReq>().await {
-                if let Ok(r) = ctx.data.0.handle_jwt(&b, &ctx.data.1).await {
                     let res = Response::from_json(&r)?;
                     return Ok(res.with_headers(post_resp_headers()?));
                 };
@@ -195,7 +180,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         .options("/witness_jwt", |_req, _ctx| preflight_response())
         .post_async("/witness_jwt", |mut req, ctx| async move {
             // TODO: REMOVE ONCE PUBLISHED TO REMOVE BACKWARDS COMPAT
-            if let Ok(b) = req.json::<CompatWitnessReq>().await {
+            if let Ok(b) = req.json::<Proofs>().await {
                 if let Ok(r) = ctx.data.0.handle_jwt(&b, &ctx.data.1).await {
                     let res = Response::from_json(&r)?;
                     return Ok(res.with_headers(post_resp_headers()?));
@@ -207,7 +192,7 @@ pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Respo
         .options("/witness_ld", |_req, _ctx| preflight_response())
         .post_async("/witness_ld", |mut req, ctx| async move {
             // TODO: REMOVE ONCE PUBLISHED TO REMOVE BACKWARDS COMPAT
-            if let Ok(b) = req.json::<CompatWitnessReq>().await {
+            if let Ok(b) = req.json::<Proofs>().await {
                 if let Ok(r) = ctx.data.0.handle_ld(&b, &ctx.data.1).await {
                     let res = Response::from_json(&r)?;
                     return Ok(res.with_headers(post_resp_headers()?));

--- a/rust/rebase_witness_sdk/examples/live_posts.rs
+++ b/rust/rebase_witness_sdk/examples/live_posts.rs
@@ -10,8 +10,8 @@ use url::Url;
 fn new_client(base_url: &str) -> Result<Client, String> {
     // TODO: Update to use a worker that supports LD routes.
     let endpoints = Endpoints {
-        witness_jwt: Some(Url::parse(&format!("{}/witness", base_url)).unwrap()),
-        witness_ld: None,
+        witness_jwt: Some(Url::parse(&format!("{}/witness_jwt", base_url)).unwrap()),
+        witness_ld: Some(Url::parse(&format!("{}/witness_ld", base_url)).unwrap()),
         statement: Url::parse(&format!("{}/statement", base_url)).unwrap(),
         instructions: Url::parse(&format!("{}/instructions", base_url)).unwrap(),
         verify: None,
@@ -62,9 +62,11 @@ async fn main() {
 
     let req = Proofs::DnsVerification(inner.clone());
 
-    client.witness_jwt(req).await.unwrap();
+    client.witness_jwt(req.clone()).await.unwrap();
+    println!("DNS jwt issued");
 
-    println!("DNS credential issued");
+    client.witness_ld(req).await.unwrap();
+    println!("DNS ld issued");
 
     println!("Tesing GitHub...");
     let did = test_eth_did();
@@ -88,9 +90,10 @@ async fn main() {
 
     let req = Proofs::GitHubVerification(proof);
 
-    client.witness_jwt(req).await.unwrap();
-
-    println!("GitHub credential issued");
+    client.witness_jwt(req.clone()).await.unwrap();
+    println!("GitHub jwt issued");
+    client.witness_ld(req).await.unwrap();
+    println!("GitHub ld issued");
 
     println!("Testing Reddit...");
     let did = test_eth_did();
@@ -109,9 +112,10 @@ async fn main() {
 
     let req = Proofs::RedditVerification(inner);
 
-    client.witness_jwt(req).await.unwrap();
-
-    println!("Reddit credential issued");
+    client.witness_jwt(req.clone()).await.unwrap();
+    println!("Reddit jwt issued");
+    client.witness_ld(req).await.unwrap();
+    println!("Reddit ld issued");
 
     println!("Testing SoundCloud...");
     let did = test_eth_did();
@@ -130,9 +134,10 @@ async fn main() {
 
     let req = Proofs::SoundCloudVerification(inner);
 
-    client.witness_jwt(req).await.unwrap();
-
-    println!("SoundCloud credential issued");
+    client.witness_jwt(req.clone()).await.unwrap();
+    println!("SoundCloud jwt issued");
+    client.witness_ld(req).await.unwrap();
+    println!("SoundCloud ld issued");
 
     println!("Testing Twitter...");
 
@@ -143,13 +148,10 @@ async fn main() {
     };
 
     let opts = Statements::TwitterVerification(inner.clone());
-
     let statement = opts.generate_statement().unwrap();
-
     check_statement(&client, opts, &statement).await.unwrap();
 
     println!("Twitter statement valid...");
-
     let proof = proof::twitter_verification::TwitterVerificationProof {
         tweet_url: "https://twitter.com/evalapplyquote/status/1542901885815820288".to_string(),
         statement: inner,
@@ -157,9 +159,10 @@ async fn main() {
 
     let req = Proofs::TwitterVerification(proof);
 
-    client.witness_jwt(req).await.unwrap();
-
-    println!("Twitter credential issued");
+    client.witness_jwt(req.clone()).await.unwrap();
+    println!("Twitter jwt issued");
+    client.witness_ld(req).await.unwrap();
+    println!("Twitter ld issued");
 
     println!("Testing Self Signed...");
 
@@ -187,7 +190,10 @@ async fn main() {
 
     let req = Proofs::SameControllerAssertion(proof);
 
-    client.witness_jwt(req).await.unwrap();
+    client.witness_jwt(req.clone()).await.unwrap();
+    println!("SameControl jwt issued");
+    client.witness_ld(req).await.unwrap();
+    println!("SameControl ld issued");
 
     println!("Self Signed Credential issued");
     println!("All Ethereum Live Posts tested!");
@@ -216,9 +222,11 @@ async fn main() {
 
     let req = Proofs::GitHubVerification(proof);
 
-    client.witness_jwt(req).await.unwrap();
+    client.witness_jwt(req.clone()).await.unwrap();
+    println!("GitHub jwt issued");
+    client.witness_ld(req).await.unwrap();
+    println!("GitHub ld issued");
 
-    println!("GitHub credential issued");
     println!("Testing Twitter...");
 
     let did = test_solana_did();
@@ -242,9 +250,10 @@ async fn main() {
 
     let req = Proofs::TwitterVerification(proof);
 
-    client.witness_jwt(req).await.unwrap();
-
-    println!("Twitter credential issued");
+    client.witness_jwt(req.clone()).await.unwrap();
+    println!("Twitter jwt issued");
+    client.witness_ld(req).await.unwrap();
+    println!("Twitter ld issued");
 
     println!("Testing Self Signed...");
 
@@ -271,9 +280,10 @@ async fn main() {
 
     let req = Proofs::SameControllerAssertion(proof);
 
-    client.witness_jwt(req).await.unwrap();
-
-    println!("Self Signed Credential issued");
+    client.witness_jwt(req.clone()).await.unwrap();
+    println!("Self Signed jwt issued");
+    client.witness_ld(req).await.unwrap();
+    println!("Self Signed ld issued");
 
     println!("All Live Posts tested!");
 }

--- a/rust/rebase_witness_sdk/src/types.rs
+++ b/rust/rebase_witness_sdk/src/types.rs
@@ -74,129 +74,6 @@ pub enum FlowType {
     SoundCloudVerification,
     TwitterVerification,
     Attestation,
-    // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-    WitnessedSelfIssued,
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-#[derive(Deserialize, Serialize, TS)]
-#[ts(export)]
-pub enum CompatContents {
-    WitnessedBasicImage(rebase::content::attestation::basic_image_attestation::BasicImageAttestationContent),
-    WitnessedBasicPost(rebase::content::attestation::basic_post_attestation::BasicPostAttestationContent),
-    WitnessedBasicProfile(rebase::content::attestation::basic_profile_attestation::BasicProfileAttestationContent),
-    WitnessedBasicTag(rebase::content::attestation::basic_tag_attestation::BasicTagAttestationContent),
-    WitnessedBookReview(rebase::content::attestation::book_review_attestation::BookReviewAttestationContent),
-    WitnessedDappPreferences(rebase::content::attestation::dapp_preferences_attestation::DappPreferencesAttestationContent),
-    WitnessedFollow(rebase::content::attestation::follow_attestation::FollowAttestationContent),
-    WitnessedLike(rebase::content::attestation::like_attestation::LikeAttestationContent),
-    WitnessedProgressBookLink(rebase::content::attestation::progress_book_link_attestation::ProgressBookLinkAttestationContent),
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-impl CompatContents {
-    pub fn to_attestation(&self) -> AttestationContent {
-        match &self {
-            CompatContents::WitnessedBasicImage(x) => {
-                AttestationContent::BasicImageAttestation(x.clone())
-            }
-            CompatContents::WitnessedBasicPost(x) => {
-                AttestationContent::BasicPostAttestation(x.clone())
-            }
-            CompatContents::WitnessedBasicProfile(x) => {
-                AttestationContent::BasicProfileAttestation(x.clone())
-            }
-            CompatContents::WitnessedBasicTag(x) => {
-                AttestationContent::BasicTagAttestation(x.clone())
-            }
-            CompatContents::WitnessedBookReview(x) => {
-                AttestationContent::BookReviewAttestation(x.clone())
-            }
-            CompatContents::WitnessedDappPreferences(x) => {
-                AttestationContent::DappPreferencesAttestation(x.clone())
-            }
-            CompatContents::WitnessedFollow(x) => AttestationContent::FollowAttestation(x.clone()),
-            CompatContents::WitnessedLike(x) => AttestationContent::LikeAttestation(x.clone()),
-            CompatContents::WitnessedProgressBookLink(x) => {
-                AttestationContent::ProgressBookLinkAttestation(x.clone())
-            }
-        }
-    }
-
-    pub fn from_attestation(attestation: AttestationContent) -> CompatContents {
-        match attestation {
-            AttestationContent::BasicImageAttestation(x) => CompatContents::WitnessedBasicImage(x),
-            AttestationContent::BasicPostAttestation(x) => CompatContents::WitnessedBasicPost(x),
-            AttestationContent::BasicProfileAttestation(x) => {
-                CompatContents::WitnessedBasicProfile(x)
-            }
-            AttestationContent::BasicTagAttestation(x) => CompatContents::WitnessedBasicTag(x),
-            AttestationContent::BookReviewAttestation(x) => CompatContents::WitnessedBookReview(x),
-            AttestationContent::DappPreferencesAttestation(x) => {
-                CompatContents::WitnessedDappPreferences(x)
-            }
-            AttestationContent::FollowAttestation(x) => CompatContents::WitnessedFollow(x),
-            AttestationContent::LikeAttestation(x) => CompatContents::WitnessedLike(x),
-            AttestationContent::ProgressBookLinkAttestation(x) => {
-                CompatContents::WitnessedProgressBookLink(x)
-            }
-        }
-    }
-
-    pub fn compat_types(&self) -> Vec<String> {
-        match &self {
-            CompatContents::WitnessedBasicImage(_) => {
-                vec![
-                    "VerifiableCredential".to_owned(),
-                    "WitnessedBasicImage".to_owned(),
-                ]
-            }
-            CompatContents::WitnessedBasicPost(_) => {
-                vec![
-                    "VerifiableCredential".to_owned(),
-                    "WitnessedBasicPost".to_owned(),
-                ]
-            }
-            CompatContents::WitnessedBasicProfile(_) => {
-                vec![
-                    "VerifiableCredential".to_owned(),
-                    "WitnessedBasicProfile".to_owned(),
-                ]
-            }
-            CompatContents::WitnessedBasicTag(_) => {
-                vec![
-                    "VerifiableCredential".to_owned(),
-                    "WitnessedBasicTag".to_owned(),
-                ]
-            }
-            CompatContents::WitnessedBookReview(_) => {
-                vec![
-                    "VerifiableCredential".to_owned(),
-                    "WitnessedBookReview".to_owned(),
-                ]
-            }
-            CompatContents::WitnessedDappPreferences(_) => {
-                vec![
-                    "VerifiableCredential".to_owned(),
-                    "WitnessedDappPreferences".to_owned(),
-                ]
-            }
-            CompatContents::WitnessedFollow(_) => vec![
-                "VerifiableCredential".to_owned(),
-                "WitnessedFollow".to_owned(),
-            ],
-            CompatContents::WitnessedLike(_) => vec![
-                "VerifiableCredential".to_owned(),
-                "WitnessedLike".to_owned(),
-            ],
-            CompatContents::WitnessedProgressBookLink(_) => {
-                vec![
-                    "VerifiableCredential".to_owned(),
-                    "WitnessedProgressBookLink".to_owned(),
-                ]
-            }
-        }
-    }
 }
 
 #[derive(Deserialize, Serialize, TS)]
@@ -212,8 +89,6 @@ pub enum Contents {
     SoundCloudVerification(SoundCloudVerificationContent),
     TwitterVerification(TwitterVerificationContent),
     Attestation(AttestationContent),
-    // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-    WitnessedSelfIssued(CompatContents),
 }
 
 #[async_trait(?Send)]
@@ -230,8 +105,6 @@ impl Content for Contents {
             Contents::SoundCloudVerification(x) => x.context(),
             Contents::TwitterVerification(x) => x.context(),
             Contents::Attestation(x) => x.context(),
-            // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-            Contents::WitnessedSelfIssued(x) => x.to_attestation().context(),
         }
     }
 
@@ -247,8 +120,6 @@ impl Content for Contents {
             Contents::SoundCloudVerification(x) => x.evidence(),
             Contents::TwitterVerification(x) => x.evidence(),
             Contents::Attestation(x) => x.evidence(),
-            // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-            Contents::WitnessedSelfIssued(x) => x.to_attestation().evidence(),
         }
     }
 
@@ -264,8 +135,6 @@ impl Content for Contents {
             Contents::SoundCloudVerification(x) => x.subject(),
             Contents::TwitterVerification(x) => x.subject(),
             Contents::Attestation(x) => x.subject(),
-            // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-            Contents::WitnessedSelfIssued(x) => x.to_attestation().subject(),
         }
     }
 
@@ -281,56 +150,6 @@ impl Content for Contents {
             Contents::SoundCloudVerification(x) => x.types(),
             Contents::TwitterVerification(x) => x.types(),
             Contents::Attestation(x) => x.types(),
-            // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-            Contents::WitnessedSelfIssued(x) => Ok(x.compat_types()),
-        }
-    }
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-#[derive(Deserialize, Serialize, TS, Clone)]
-#[ts(export)]
-pub enum CompatStatements {
-    WitnessedBasicImage(rebase::statement::attestation::basic_image_attestation::BasicImageAttestationStatement),
-    WitnessedBasicPost(rebase::statement::attestation::basic_post_attestation::BasicPostAttestationStatement),
-    WitnessedBasicProfile(rebase::statement::attestation::basic_profile_attestation::BasicProfileAttestationStatement),
-    WitnessedBasicTag(rebase::statement::attestation::basic_tag_attestation::BasicTagAttestationStatement),
-    WitnessedBookReview(rebase::statement::attestation::book_review_attestation::BookReviewAttestationStatement),
-    WitnessedDappPreferences(rebase::statement::attestation::dapp_preferences_attestation::DappPreferencesAttestationStatement),
-    WitnessedFollow(rebase::statement::attestation::follow_attestation::FollowAttestationStatement),
-    WitnessedLike(rebase::statement::attestation::like_attestation::LikeAttestationStatement),
-    WitnessedProgressBookLink(rebase::statement::attestation::progress_book_link_attestation::ProgressBookLinkAttestationStatement),
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-impl CompatStatements {
-    pub fn to_attestation(&self) -> AttestationStatement {
-        match &self {
-            CompatStatements::WitnessedBasicImage(x) => {
-                AttestationStatement::BasicImageAttestation(x.clone())
-            }
-            CompatStatements::WitnessedBasicPost(x) => {
-                AttestationStatement::BasicPostAttestation(x.clone())
-            }
-            CompatStatements::WitnessedBasicProfile(x) => {
-                AttestationStatement::BasicProfileAttestation(x.clone())
-            }
-            CompatStatements::WitnessedBasicTag(x) => {
-                AttestationStatement::BasicTagAttestation(x.clone())
-            }
-            CompatStatements::WitnessedBookReview(x) => {
-                AttestationStatement::BookReviewAttestation(x.clone())
-            }
-            CompatStatements::WitnessedDappPreferences(x) => {
-                AttestationStatement::DappPreferencesAttestation(x.clone())
-            }
-            CompatStatements::WitnessedFollow(x) => {
-                AttestationStatement::FollowAttestation(x.clone())
-            }
-            CompatStatements::WitnessedLike(x) => AttestationStatement::LikeAttestation(x.clone()),
-            CompatStatements::WitnessedProgressBookLink(x) => {
-                AttestationStatement::ProgressBookLinkAttestation(x.clone())
-            }
         }
     }
 }
@@ -351,8 +170,6 @@ pub enum Statements {
     SoundCloudVerification(SoundCloudVerificationStatement),
     TwitterVerification(TwitterVerificationStatement),
     Attestation(AttestationStatement),
-    // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-    WitnessedSelfIssued(CompatStatements),
 }
 
 impl Statement for Statements {
@@ -368,52 +185,6 @@ impl Statement for Statements {
             Statements::SoundCloudVerification(x) => x.generate_statement(),
             Statements::TwitterVerification(x) => x.generate_statement(),
             Statements::Attestation(x) => x.generate_statement(),
-            // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-            Statements::WitnessedSelfIssued(x) => x.to_attestation().generate_statement(),
-        }
-    }
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-#[derive(Deserialize, Serialize, TS, Clone)]
-#[ts(export)]
-pub enum CompatProofs {
-    WitnessedBasicImage(rebase::proof::attestation::basic_image_attestation::BasicImageAttestationProof),
-    WitnessedBasicPost(rebase::proof::attestation::basic_post_attestation::BasicPostAttestationProof),
-    WitnessedBasicProfile(rebase::proof::attestation::basic_profile_attestation::BasicProfileAttestationProof),
-    WitnessedBasicTag(rebase::proof::attestation::basic_tag_attestation::BasicTagAttestationProof),
-    WitnessedBookReview(rebase::proof::attestation::book_review_attestation::BookReviewAttestationProof),
-    WitnessedDappPreferences(rebase::proof::attestation::dapp_preferences_attestation::DappPreferencesAttestationProof),
-    WitnessedFollow(rebase::proof::attestation::follow_attestation::FollowAttestationProof),
-    WitnessedLike(rebase::proof::attestation::like_attestation::LikeAttestationProof),
-    WitnessedProgressBookLink(rebase::proof::attestation::progress_book_link_attestation::ProgressBookLinkAttestationProof),
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-impl CompatProofs {
-    pub fn to_attestation(&self) -> AttestationProof {
-        match &self {
-            CompatProofs::WitnessedBasicImage(x) => {
-                AttestationProof::BasicImageAttestation(x.clone())
-            }
-            CompatProofs::WitnessedBasicPost(x) => {
-                AttestationProof::BasicPostAttestation(x.clone())
-            }
-            CompatProofs::WitnessedBasicProfile(x) => {
-                AttestationProof::BasicProfileAttestation(x.clone())
-            }
-            CompatProofs::WitnessedBasicTag(x) => AttestationProof::BasicTagAttestation(x.clone()),
-            CompatProofs::WitnessedBookReview(x) => {
-                AttestationProof::BookReviewAttestation(x.clone())
-            }
-            CompatProofs::WitnessedDappPreferences(x) => {
-                AttestationProof::DappPreferencesAttestation(x.clone())
-            }
-            CompatProofs::WitnessedFollow(x) => AttestationProof::FollowAttestation(x.clone()),
-            CompatProofs::WitnessedLike(x) => AttestationProof::LikeAttestation(x.clone()),
-            CompatProofs::WitnessedProgressBookLink(x) => {
-                AttestationProof::ProgressBookLinkAttestation(x.clone())
-            }
         }
     }
 }
@@ -434,8 +205,6 @@ pub enum Proofs {
     SoundCloudVerification(SoundCloudVerificationStatement),
     TwitterVerification(TwitterVerificationProof),
     Attestation(AttestationProof),
-    // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-    WitnessedSelfIssued(CompatProofs),
 }
 
 impl Statement for Proofs {
@@ -451,8 +220,6 @@ impl Statement for Proofs {
             Proofs::SoundCloudVerification(x) => x.generate_statement(),
             Proofs::TwitterVerification(x) => x.generate_statement(),
             Proofs::Attestation(x) => x.generate_statement(),
-            // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-            Proofs::WitnessedSelfIssued(x) => x.to_attestation().generate_statement(),
         }
     }
 }
@@ -490,10 +257,6 @@ impl Proof<Contents> for Proofs {
             Proofs::Attestation(x) => {
                 Ok(Contents::Attestation(x.to_content(statement, signature)?))
             }
-            // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-            Proofs::WitnessedSelfIssued(x) => Ok(Contents::Attestation(
-                x.to_attestation().to_content(statement, signature)?,
-            )),
         }
     }
 }
@@ -586,13 +349,6 @@ impl Flow<Contents, Statements, Proofs> for WitnessFlow {
                     "no witnessed self issued flow configured".to_owned(),
                 )),
             },
-            // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-            Statements::WitnessedSelfIssued(s) => match &self.attestation {
-                Some(x) => Ok(x.statement(&s.to_attestation(), issuer).await?),
-                None => Err(FlowError::Validation(
-                    "no witnessed self issued flow configured".to_owned(),
-                )),
-            },
         }
     }
 
@@ -678,17 +434,6 @@ impl Flow<Contents, Statements, Proofs> for WitnessFlow {
                     "no witnessed self issued flow configured".to_owned(),
                 )),
             },
-            // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-            Proofs::WitnessedSelfIssued(p) => match &self.attestation {
-                Some(x) => Ok(Contents::WitnessedSelfIssued(
-                    CompatContents::from_attestation(
-                        x.validate_proof(&p.to_attestation(), issuer).await?,
-                    ),
-                )),
-                None => Err(FlowError::Validation(
-                    "no witnessed self issued flow configured".to_owned(),
-                )),
-            },
         }
     }
 }
@@ -697,58 +442,6 @@ impl Flow<Contents, Statements, Proofs> for WitnessFlow {
 pub struct InstructionsReq {
     #[serde(rename = "type")]
     pub instruction_type: FlowType,
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-#[derive(Clone, Deserialize, Serialize, TS)]
-#[ts(export)]
-pub struct StatementReq {
-    pub opts: Statements,
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-#[derive(Clone, Deserialize, Serialize, TS)]
-#[ts(export)]
-#[serde(untagged)]
-pub enum CompatStatementReq {
-    R(StatementReq),
-    S(Statements),
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-impl CompatStatementReq {
-    pub fn to_statement(&self) -> Statements {
-        match self {
-            CompatStatementReq::R(r) => r.opts.clone(),
-            CompatStatementReq::S(s) => s.clone(),
-        }
-    }
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-#[derive(Clone, Deserialize, Serialize, TS)]
-#[ts(export)]
-pub struct WitnessReq {
-    pub proof: Proofs,
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-#[derive(Clone, Deserialize, Serialize, TS)]
-#[ts(export)]
-#[serde(untagged)]
-pub enum CompatWitnessReq {
-    R(WitnessReq),
-    P(Proofs),
-}
-
-// TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-impl CompatWitnessReq {
-    pub fn to_proofs(&self) -> Proofs {
-        match self {
-            CompatWitnessReq::R(r) => r.proof.clone(),
-            CompatWitnessReq::P(p) => p.clone(),
-        }
-    }
 }
 
 #[derive(Clone, Deserialize, Serialize, TS)]
@@ -837,31 +530,23 @@ impl WitnessFlow {
                     "no witnessed self issued flow configured".to_owned(),
                 )),
             },
-            FlowType::WitnessedSelfIssued => match &self.attestation {
-                Some(x) => x.instructions(),
-                _ => Err(FlowError::Validation(
-                    "no witnessed self issued flow configured".to_owned(),
-                )),
-            },
         }
     }
 
     pub async fn handle_ld<I: Issuer>(
         &self,
-        // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-        proof: &CompatWitnessReq,
+        proof: &Proofs,
         issuer: &I,
     ) -> Result<serde_json::Value, FlowError> {
-        Ok(json!({ "credential": self.credential(&proof.to_proofs(), issuer).await? }))
+        Ok(json!({ "credential": self.credential(proof, issuer).await? }))
     }
 
     pub async fn handle_jwt<I: Issuer>(
         &self,
-        // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-        proof: &CompatWitnessReq,
+        proof: &Proofs,
         issuer: &I,
     ) -> Result<serde_json::Value, FlowError> {
-        Ok(json!({ "jwt": self.jwt(&proof.to_proofs(), issuer).await? }))
+        Ok(json!({ "jwt": self.jwt(proof, issuer).await? }))
     }
 
     pub async fn handle_instructions(
@@ -873,13 +558,10 @@ impl WitnessFlow {
 
     pub async fn handle_statement<I: Issuer>(
         &self,
-        // TODO: REMOVE THIS ONCE ALL DEMOS HAVE BEEN MIGRATED TO PUBLISHED REBASE!
-        statement: &CompatStatementReq,
+        statement: &Statements,
         issuer: &I,
     ) -> Result<serde_json::Value, FlowError> {
-        Ok(json!(
-            self.statement(&statement.to_statement(), issuer).await?
-        ))
+        Ok(json!(self.statement(statement, issuer).await?))
     }
 }
 


### PR DESCRIPTION
This simply removes all of the code used to bridge between the two formats and leaves only the new format. This will be a much cleaner codebase to publish.

Everything should still be working, testable from the links below. 

Once Rebase is published, and all dependent projects have moved over to use the published version, a worker witness can be deployed using this leaner code base.